### PR TITLE
fix: comment block and empty oneline comment loc error

### DIFF
--- a/src/main/scanner.ts
+++ b/src/main/scanner.ts
@@ -280,7 +280,7 @@ export function createScanner(
 
     function singleLineComment(): void {
         let comment: string = ''
-
+        let emptyComment = false
         while (true) {
             if (
                 current() === '\n' ||
@@ -301,15 +301,23 @@ export function createScanner(
             }
 
             comment += current()
+        } else {
+            emptyComment = true
         }
 
         addToken(SyntaxType.CommentLine, comment.trim())
+
+        if (emptyComment) {
+            emptyComment = !emptyComment
+            nextLine()
+        }
     }
 
     // TODO: optimize the logic
     function multilineComment(): void {
         let comment: string = ''
         let cursor: number = 0
+        let commentBlockEnd = false
 
         while (true) {
             if (
@@ -355,11 +363,16 @@ export function createScanner(
             if ((peek() === '*' && peekNext() === '/') || isAtEnd()) {
                 advance()
                 advance()
+                commentBlockEnd = true
                 break
             }
         }
 
         addToken(SyntaxType.CommentBlock, comment.trim())
+        if (commentBlockEnd) {
+            commentBlockEnd = !commentBlockEnd
+            nextLine()
+        }
     }
 
     function string(terminator: string): void {

--- a/src/tests/parser/solutions/comments-mapping.solution.json
+++ b/src/tests/parser/solutions/comments-mapping.solution.json
@@ -8,12 +8,12 @@
         "value": "MyInteger",
         "loc": {
           "start": {
-            "line": 5,
+            "line": 6,
             "column": 13,
             "index": 52
           },
           "end": {
-            "line": 5,
+            "line": 6,
             "column": 22,
             "index": 61
           }
@@ -23,12 +23,12 @@
         "type": "I32Keyword",
         "loc": {
           "start": {
-            "line": 5,
+            "line": 6,
             "column": 9,
             "index": 48
           },
           "end": {
-            "line": 5,
+            "line": 6,
             "column": 12,
             "index": 51
           }
@@ -57,12 +57,12 @@
       ],
       "loc": {
         "start": {
-          "line": 5,
+          "line": 6,
           "column": 1,
           "index": 40
         },
         "end": {
-          "line": 5,
+          "line": 6,
           "column": 22,
           "index": 61
         }
@@ -75,12 +75,12 @@
         "value": "INT32CONSTANT",
         "loc": {
           "start": {
-            "line": 10,
+            "line": 12,
             "column": 11,
             "index": 99
           },
           "end": {
-            "line": 10,
+            "line": 12,
             "column": 24,
             "index": 112
           }
@@ -90,12 +90,12 @@
         "type": "I32Keyword",
         "loc": {
           "start": {
-            "line": 10,
+            "line": 12,
             "column": 7,
             "index": 95
           },
           "end": {
-            "line": 10,
+            "line": 12,
             "column": 10,
             "index": 98
           }
@@ -108,12 +108,12 @@
           "value": "9853",
           "loc": {
             "start": {
-              "line": 10,
+              "line": 12,
               "column": 27,
               "index": 115
             },
             "end": {
-              "line": 10,
+              "line": 12,
               "column": 31,
               "index": 119
             }
@@ -121,12 +121,12 @@
         },
         "loc": {
           "start": {
-            "line": 10,
+            "line": 12,
             "column": 27,
             "index": 115
           },
           "end": {
-            "line": 10,
+            "line": 12,
             "column": 31,
             "index": 119
           }
@@ -140,12 +140,12 @@
           ],
           "loc": {
             "start": {
-              "line": 7,
+              "line": 8,
               "column": 1,
               "index": 63
             },
             "end": {
-              "line": 9,
+              "line": 10,
               "column": 4,
               "index": 88
             }
@@ -154,12 +154,12 @@
       ],
       "loc": {
         "start": {
-          "line": 10,
+          "line": 12,
           "column": 1,
           "index": 89
         },
         "end": {
-          "line": 10,
+          "line": 12,
           "column": 31,
           "index": 119
         }
@@ -172,12 +172,12 @@
         "value": "STRINGCONSTANT",
         "loc": {
           "start": {
-            "line": 13,
+            "line": 15,
             "column": 14,
             "index": 152
           },
           "end": {
-            "line": 13,
+            "line": 15,
             "column": 28,
             "index": 166
           }
@@ -187,12 +187,12 @@
         "type": "StringKeyword",
         "loc": {
           "start": {
-            "line": 13,
+            "line": 15,
             "column": 7,
             "index": 145
           },
           "end": {
-            "line": 13,
+            "line": 15,
             "column": 13,
             "index": 151
           }
@@ -203,12 +203,12 @@
         "value": "hello world",
         "loc": {
           "start": {
-            "line": 13,
+            "line": 15,
             "column": 31,
             "index": 169
           },
           "end": {
-            "line": 13,
+            "line": 15,
             "column": 44,
             "index": 182
           }
@@ -220,12 +220,12 @@
           "value": "Const2 comment",
           "loc": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
               "index": 121
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 18,
               "index": 138
             }
@@ -234,12 +234,12 @@
       ],
       "loc": {
         "start": {
-          "line": 13,
+          "line": 15,
           "column": 1,
           "index": 139
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 44,
           "index": 182
         }
@@ -252,12 +252,12 @@
         "value": "Operation",
         "loc": {
           "start": {
-            "line": 18,
+            "line": 21,
             "column": 6,
             "index": 213
           },
           "end": {
-            "line": 18,
+            "line": 21,
             "column": 15,
             "index": 222
           }
@@ -271,12 +271,12 @@
             "value": "ADD",
             "loc": {
               "start": {
-                "line": 19,
+                "line": 22,
                 "column": 3,
                 "index": 227
               },
               "end": {
-                "line": 19,
+                "line": 22,
                 "column": 6,
                 "index": 230
               }
@@ -289,12 +289,12 @@
               "value": "1",
               "loc": {
                 "start": {
-                  "line": 19,
+                  "line": 22,
                   "column": 9,
                   "index": 233
                 },
                 "end": {
-                  "line": 19,
+                  "line": 22,
                   "column": 10,
                   "index": 234
                 }
@@ -302,12 +302,12 @@
             },
             "loc": {
               "start": {
-                "line": 19,
+                "line": 22,
                 "column": 9,
                 "index": 233
               },
               "end": {
-                "line": 19,
+                "line": 22,
                 "column": 10,
                 "index": 234
               }
@@ -316,12 +316,12 @@
           "comments": [],
           "loc": {
             "start": {
-              "line": 19,
+              "line": 22,
               "column": 3,
               "index": 227
             },
             "end": {
-              "line": 19,
+              "line": 22,
               "column": 10,
               "index": 234
             }
@@ -334,12 +334,12 @@
             "value": "MULTIPLY",
             "loc": {
               "start": {
-                "line": 21,
+                "line": 24,
                 "column": 3,
                 "index": 262
               },
               "end": {
-                "line": 21,
+                "line": 24,
                 "column": 11,
                 "index": 270
               }
@@ -348,30 +348,30 @@
           "initializer": null,
           "comments": [
             {
-              "loc": {
-                "end": {
-                  "column": 24,
-                  "index": 259,
-                  "line": 20
-                },
-                "start": {
-                  "column": 3,
-                  "index": 238,
-                  "line": 20
-                }
-              },
               "type": "CommentLine",
-              "value": "Enum field comment"
+              "value": "Enum field comment",
+              "loc": {
+                "start": {
+                  "line": 23,
+                  "column": 3,
+                  "index": 238
+                },
+                "end": {
+                  "line": 23,
+                  "column": 24,
+                  "index": 259
+                }
+              }
             }
           ],
           "loc": {
             "start": {
-              "line": 21,
+              "line": 24,
               "column": 3,
               "index": 262
             },
             "end": {
-              "line": 21,
+              "line": 24,
               "column": 11,
               "index": 270
             }
@@ -386,12 +386,12 @@
           ],
           "loc": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
               "index": 184
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 4,
               "index": 207
             }
@@ -400,12 +400,12 @@
       ],
       "loc": {
         "start": {
-          "line": 18,
+          "line": 21,
           "column": 1,
           "index": 208
         },
         "end": {
-          "line": 22,
+          "line": 25,
           "column": 2,
           "index": 272
         }
@@ -418,12 +418,12 @@
         "value": "Work",
         "loc": {
           "start": {
-            "line": 27,
+            "line": 31,
             "column": 8,
             "index": 307
           },
           "end": {
-            "line": 27,
+            "line": 31,
             "column": 12,
             "index": 311
           }
@@ -437,12 +437,12 @@
             "value": "num1",
             "loc": {
               "start": {
-                "line": 28,
+                "line": 32,
                 "column": 10,
                 "index": 323
               },
               "end": {
-                "line": 28,
+                "line": 32,
                 "column": 14,
                 "index": 327
               }
@@ -453,12 +453,12 @@
             "value": 1,
             "loc": {
               "start": {
-                "line": 28,
+                "line": 32,
                 "column": 3,
                 "index": 316
               },
               "end": {
-                "line": 28,
+                "line": 32,
                 "column": 5,
                 "index": 318
               }
@@ -468,12 +468,12 @@
             "type": "I32Keyword",
             "loc": {
               "start": {
-                "line": 28,
+                "line": 32,
                 "column": 6,
                 "index": 319
               },
               "end": {
-                "line": 28,
+                "line": 32,
                 "column": 9,
                 "index": 322
               }
@@ -487,12 +487,12 @@
               "value": "0",
               "loc": {
                 "start": {
-                  "line": 28,
+                  "line": 32,
                   "column": 17,
                   "index": 330
                 },
                 "end": {
-                  "line": 28,
+                  "line": 32,
                   "column": 18,
                   "index": 331
                 }
@@ -500,12 +500,12 @@
             },
             "loc": {
               "start": {
-                "line": 28,
+                "line": 32,
                 "column": 17,
                 "index": 330
               },
               "end": {
-                "line": 28,
+                "line": 32,
                 "column": 18,
                 "index": 331
               }
@@ -514,12 +514,12 @@
           "comments": [],
           "loc": {
             "start": {
-              "line": 28,
+              "line": 32,
               "column": 3,
               "index": 316
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 19,
               "index": 332
             }
@@ -532,12 +532,12 @@
             "value": "op",
             "loc": {
               "start": {
-                "line": 30,
+                "line": 34,
                 "column": 16,
                 "index": 374
               },
               "end": {
-                "line": 30,
+                "line": 34,
                 "column": 18,
                 "index": 376
               }
@@ -548,12 +548,12 @@
             "value": 2,
             "loc": {
               "start": {
-                "line": 30,
+                "line": 34,
                 "column": 3,
                 "index": 361
               },
               "end": {
-                "line": 30,
+                "line": 34,
                 "column": 5,
                 "index": 363
               }
@@ -564,12 +564,12 @@
             "value": "Operation",
             "loc": {
               "start": {
-                "line": 30,
+                "line": 34,
                 "column": 6,
                 "index": 364
               },
               "end": {
-                "line": 30,
+                "line": 34,
                 "column": 15,
                 "index": 373
               }
@@ -579,30 +579,30 @@
           "defaultValue": null,
           "comments": [
             {
-              "loc": {
-                "end": {
-                  "column": 26,
-                  "index": 358,
-                  "line": 29
-                },
-                "start": {
-                  "column": 3,
-                  "index": 335,
-                  "line": 29
-                }
-              },
               "type": "CommentLine",
-              "value": "Struct field comment"
+              "value": "Struct field comment",
+              "loc": {
+                "start": {
+                  "line": 33,
+                  "column": 3,
+                  "index": 335
+                },
+                "end": {
+                  "line": 33,
+                  "column": 26,
+                  "index": 358
+                }
+              }
             }
           ],
           "loc": {
             "start": {
-              "line": 30,
+              "line": 34,
               "column": 3,
               "index": 361
             },
             "end": {
-              "line": 30,
+              "line": 34,
               "column": 19,
               "index": 377
             }
@@ -617,12 +617,12 @@
           ],
           "loc": {
             "start": {
-              "line": 24,
+              "line": 27,
               "column": 1,
               "index": 274
             },
             "end": {
-              "line": 26,
+              "line": 29,
               "column": 4,
               "index": 299
             }
@@ -631,12 +631,12 @@
       ],
       "loc": {
         "start": {
-          "line": 27,
+          "line": 31,
           "column": 1,
           "index": 300
         },
         "end": {
-          "line": 31,
+          "line": 35,
           "column": 2,
           "index": 379
         }
@@ -649,12 +649,12 @@
         "value": "Calculator",
         "loc": {
           "start": {
-            "line": 36,
+            "line": 41,
             "column": 9,
             "index": 416
           },
           "end": {
-            "line": 36,
+            "line": 41,
             "column": 19,
             "index": 426
           }
@@ -665,12 +665,12 @@
         "value": "shared.SharedService",
         "loc": {
           "start": {
-            "line": 36,
+            "line": 41,
             "column": 20,
             "index": 427
           },
           "end": {
-            "line": 36,
+            "line": 41,
             "column": 48,
             "index": 455
           }
@@ -684,12 +684,12 @@
             "value": "add",
             "loc": {
               "start": {
-                "line": 42,
+                "line": 48,
                 "column": 8,
                 "index": 503
               },
               "end": {
-                "line": 42,
+                "line": 48,
                 "column": 11,
                 "index": 506
               }
@@ -699,12 +699,12 @@
             "type": "I32Keyword",
             "loc": {
               "start": {
-                "line": 42,
+                "line": 48,
                 "column": 4,
                 "index": 499
               },
               "end": {
-                "line": 42,
+                "line": 48,
                 "column": 7,
                 "index": 502
               }
@@ -718,12 +718,12 @@
                 "value": "num1",
                 "loc": {
                   "start": {
-                    "line": 42,
+                    "line": 48,
                     "column": 24,
                     "index": 519
                   },
                   "end": {
-                    "line": 42,
+                    "line": 48,
                     "column": 28,
                     "index": 523
                   }
@@ -734,12 +734,12 @@
                 "value": 1,
                 "loc": {
                   "start": {
-                    "line": 42,
+                    "line": 48,
                     "column": 12,
                     "index": 507
                   },
                   "end": {
-                    "line": 42,
+                    "line": 48,
                     "column": 14,
                     "index": 509
                   }
@@ -750,12 +750,12 @@
                 "value": "MyInteger",
                 "loc": {
                   "start": {
-                    "line": 42,
+                    "line": 48,
                     "column": 14,
                     "index": 509
                   },
                   "end": {
-                    "line": 42,
+                    "line": 48,
                     "column": 23,
                     "index": 518
                   }
@@ -766,12 +766,12 @@
               "comments": [],
               "loc": {
                 "start": {
-                  "line": 42,
+                  "line": 48,
                   "column": 12,
                   "index": 507
                 },
                 "end": {
-                  "line": 42,
+                  "line": 48,
                   "column": 29,
                   "index": 524
                 }
@@ -784,12 +784,12 @@
                 "value": "num2",
                 "loc": {
                   "start": {
-                    "line": 42,
+                    "line": 48,
                     "column": 36,
                     "index": 531
                   },
                   "end": {
-                    "line": 42,
+                    "line": 48,
                     "column": 40,
                     "index": 535
                   }
@@ -800,12 +800,12 @@
                 "value": 2,
                 "loc": {
                   "start": {
-                    "line": 42,
+                    "line": 48,
                     "column": 30,
                     "index": 525
                   },
                   "end": {
-                    "line": 42,
+                    "line": 48,
                     "column": 32,
                     "index": 527
                   }
@@ -815,12 +815,12 @@
                 "type": "I32Keyword",
                 "loc": {
                   "start": {
-                    "line": 42,
+                    "line": 48,
                     "column": 32,
                     "index": 527
                   },
                   "end": {
-                    "line": 42,
+                    "line": 48,
                     "column": 35,
                     "index": 530
                   }
@@ -831,12 +831,12 @@
               "comments": [],
               "loc": {
                 "start": {
-                  "line": 42,
+                  "line": 48,
                   "column": 30,
                   "index": 525
                 },
                 "end": {
-                  "line": 42,
+                  "line": 48,
                   "column": 40,
                   "index": 535
                 }
@@ -852,12 +852,12 @@
               ],
               "loc": {
                 "start": {
-                  "line": 38,
+                  "line": 43,
                   "column": 3,
                   "index": 461
                 },
                 "end": {
-                  "line": 40,
+                  "line": 45,
                   "column": 6,
                   "index": 494
                 }
@@ -868,12 +868,12 @@
           "modifiers": [],
           "loc": {
             "start": {
-              "line": 42,
+              "line": 48,
               "column": 4,
               "index": 499
             },
             "end": {
-              "line": 42,
+              "line": 48,
               "column": 42,
               "index": 537
             }
@@ -886,12 +886,12 @@
             "value": "zip",
             "loc": {
               "start": {
-                "line": 47,
+                "line": 54,
                 "column": 16,
                 "index": 591
               },
               "end": {
-                "line": 47,
+                "line": 54,
                 "column": 19,
                 "index": 594
               }
@@ -901,12 +901,12 @@
             "type": "VoidKeyword",
             "loc": {
               "start": {
-                "line": 47,
+                "line": 54,
                 "column": 11,
                 "index": 586
               },
               "end": {
-                "line": 47,
+                "line": 54,
                 "column": 15,
                 "index": 590
               }
@@ -920,12 +920,12 @@
                 "value": "vasia",
                 "loc": {
                   "start": {
-                    "line": 47,
+                    "line": 54,
                     "column": 26,
                     "index": 601
                   },
                   "end": {
-                    "line": 47,
+                    "line": 54,
                     "column": 31,
                     "index": 606
                   }
@@ -936,12 +936,12 @@
                 "value": 1,
                 "loc": {
                   "start": {
-                    "line": 47,
+                    "line": 54,
                     "column": 20,
                     "index": 595
                   },
                   "end": {
-                    "line": 47,
+                    "line": 54,
                     "column": 22,
                     "index": 597
                   }
@@ -951,12 +951,12 @@
                 "type": "I32Keyword",
                 "loc": {
                   "start": {
-                    "line": 47,
+                    "line": 54,
                     "column": 22,
                     "index": 597
                   },
                   "end": {
-                    "line": 47,
+                    "line": 54,
                     "column": 25,
                     "index": 600
                   }
@@ -967,12 +967,12 @@
               "comments": [],
               "loc": {
                 "start": {
-                  "line": 47,
+                  "line": 54,
                   "column": 20,
                   "index": 595
                 },
                 "end": {
-                  "line": 47,
+                  "line": 54,
                   "column": 31,
                   "index": 606
                 }
@@ -988,12 +988,12 @@
               ],
               "loc": {
                 "start": {
-                  "line": 44,
+                  "line": 50,
                   "column": 4,
                   "index": 542
                 },
                 "end": {
-                  "line": 46,
+                  "line": 52,
                   "column": 6,
                   "index": 575
                 }
@@ -1007,12 +1007,12 @@
               "text": "oneway",
               "loc": {
                 "start": {
-                  "line": 47,
+                  "line": 54,
                   "column": 4,
                   "index": 579
                 },
                 "end": {
-                  "line": 47,
+                  "line": 54,
                   "column": 10,
                   "index": 585
                 }
@@ -1021,12 +1021,12 @@
           ],
           "loc": {
             "start": {
-              "line": 47,
+              "line": 54,
               "column": 11,
               "index": 586
             },
             "end": {
-              "line": 47,
+              "line": 54,
               "column": 32,
               "index": 607
             }
@@ -1041,12 +1041,12 @@
           ],
           "loc": {
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 1,
               "index": 381
             },
             "end": {
-              "line": 35,
+              "line": 39,
               "column": 4,
               "index": 407
             }
@@ -1055,12 +1055,12 @@
       ],
       "loc": {
         "start": {
-          "line": 36,
+          "line": 41,
           "column": 1,
           "index": 408
         },
         "end": {
-          "line": 49,
+          "line": 56,
           "column": 2,
           "index": 610
         }

--- a/src/tests/parser/solutions/complex-comments.solution.json
+++ b/src/tests/parser/solutions/complex-comments.solution.json
@@ -1,179 +1,179 @@
 {
-    "type": "ThriftDocument",
-    "body": [
+  "type": "ThriftDocument",
+  "body": [
+    {
+      "type": "ServiceDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "Test",
+        "loc": {
+          "start": {
+            "line": 11,
+            "column": 9,
+            "index": 137
+          },
+          "end": {
+            "line": 11,
+            "column": 13,
+            "index": 141
+          }
+        }
+      },
+      "extends": null,
+      "functions": [
         {
-            "type": "ServiceDefinition",
-            "name": {
-                "type": "Identifier",
-                "value": "Test",
-                "loc": {
-                    "start": {
-                        "line": 9,
-                        "column": 9,
-                        "index": 137
-                    },
-                    "end": {
-                        "line": 9,
-                        "column": 13,
-                        "index": 141
-                    }
-                }
-            },
-            "extends": null,
-            "functions": [
-                {
-                    "type": "FunctionDefinition",
-                    "name": {
-                        "type": "Identifier",
-                        "value": "ding",
-                        "loc": {
-                            "start": {
-                                "line": 12,
-                                "column": 9,
-                                "index": 192
-                            },
-                            "end": {
-                                "line": 12,
-                                "column": 13,
-                                "index": 196
-                            }
-                        }
-                    },
-                    "returnType": {
-                        "type": "I32Keyword",
-                        "loc": {
-                            "start": {
-                                "line": 12,
-                                "column": 5,
-                                "index": 188
-                            },
-                            "end": {
-                                "line": 12,
-                                "column": 8,
-                                "index": 191
-                            }
-                        }
-                    },
-                    "fields": [],
-                    "throws": [],
-                    "comments": [
-                        {
-                            "type": "CommentLine",
-                            "value": "bool foo();",
-                            "loc": {
-                                "start": {
-                                    "line": 10,
-                                    "column": 5,
-                                    "index": 148
-                                },
-                                "end": {
-                                    "line": 10,
-                                    "column": 18,
-                                    "index": 161
-                                }
-                            }
-                        },
-                        {
-                            "type": "CommentLine",
-                            "value": "string dang(),",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 5,
-                                    "index": 166
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 22,
-                                    "index": 183
-                                }
-                            }
-                        }
-                    ],
-                    "oneway": false,
-                    "modifiers": [],
-                    "loc": {
-                        "start": {
-                            "line": 12,
-                            "column": 5,
-                            "index": 188
-                        },
-                        "end": {
-                            "line": 12,
-                            "column": 15,
-                            "index": 198
-                        }
-                    }
-                }
-            ],
-            "comments": [
-                {
-                    "type": "CommentLine",
-                    "value": "This service does nothing",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 1,
-                            "index": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 29,
-                            "index": 28
-                        }
-                    }
-                },
-                {
-                    "type": "CommentBlock",
-                    "value": [
-                        "This is a multi-line",
-                        " comment for testing"
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 1,
-                            "index": 29
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 4,
-                            "index": 82
-                        }
-                    }
-                },
-                {
-                    "type": "CommentBlock",
-                    "value": [
-                        "Another muliti-line",
-                        "comment for testing"
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 6,
-                            "column": 1,
-                            "index": 83
-                        },
-                        "end": {
-                            "line": 8,
-                            "column": 23,
-                            "index": 128
-                        }
-                    }
-                }
-            ],
+          "type": "FunctionDefinition",
+          "name": {
+            "type": "Identifier",
+            "value": "ding",
             "loc": {
+              "start": {
+                "line": 14,
+                "column": 9,
+                "index": 192
+              },
+              "end": {
+                "line": 14,
+                "column": 13,
+                "index": 196
+              }
+            }
+          },
+          "returnType": {
+            "type": "I32Keyword",
+            "loc": {
+              "start": {
+                "line": 14,
+                "column": 5,
+                "index": 188
+              },
+              "end": {
+                "line": 14,
+                "column": 8,
+                "index": 191
+              }
+            }
+          },
+          "fields": [],
+          "throws": [],
+          "comments": [
+            {
+              "type": "CommentLine",
+              "value": "bool foo();",
+              "loc": {
                 "start": {
-                    "line": 9,
-                    "column": 1,
-                    "index": 129
+                  "line": 12,
+                  "column": 5,
+                  "index": 148
                 },
                 "end": {
-                    "line": 13,
-                    "column": 2,
-                    "index": 200
+                  "line": 12,
+                  "column": 18,
+                  "index": 161
                 }
+              }
+            },
+            {
+              "type": "CommentLine",
+              "value": "string dang(),",
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 5,
+                  "index": 166
+                },
+                "end": {
+                  "line": 13,
+                  "column": 22,
+                  "index": 183
+                }
+              }
             }
+          ],
+          "oneway": false,
+          "modifiers": [],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 5,
+              "index": 188
+            },
+            "end": {
+              "line": 14,
+              "column": 15,
+              "index": 198
+            }
+          }
         }
-    ]
+      ],
+      "comments": [
+        {
+          "type": "CommentLine",
+          "value": "This service does nothing",
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "index": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 29,
+              "index": 28
+            }
+          }
+        },
+        {
+          "type": "CommentBlock",
+          "value": [
+            "This is a multi-line",
+            " comment for testing"
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 1,
+              "index": 29
+            },
+            "end": {
+              "line": 5,
+              "column": 4,
+              "index": 82
+            }
+          }
+        },
+        {
+          "type": "CommentBlock",
+          "value": [
+            "Another muliti-line",
+            "comment for testing"
+          ],
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 1,
+              "index": 83
+            },
+            "end": {
+              "line": 9,
+              "column": 23,
+              "index": 128
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "index": 129
+        },
+        "end": {
+          "line": 15,
+          "column": 2,
+          "index": 200
+        }
+      }
+    }
+  ]
 }

--- a/src/tests/parser/solutions/enum-commented.solution.json
+++ b/src/tests/parser/solutions/enum-commented.solution.json
@@ -1,89 +1,91 @@
 {
-    "type": "ThriftDocument",
-    "body": [
+  "type": "ThriftDocument",
+  "body": [
+    {
+      "type": "EnumDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "Test",
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 6,
+            "index": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 10,
+            "index": 9
+          }
+        }
+      },
+      "members": [
         {
-            "type": "EnumDefinition",
-            "name": {
-                "type": "Identifier",
-                "value": "Test",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 6,
-                        "index": 5
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 10,
-                        "index": 9
-                    }
-                }
-            },
-            "members": [
-                {
-                    "type": "EnumMember",
-                    "name": {
-                        "type": "Identifier",
-                        "value": "ONE",
-                        "loc": {
-                            "start": {
-                                "line": 2,
-                                "column": 5,
-                                "index": 16
-                            },
-                            "end": {
-                                "line": 2,
-                                "column": 8,
-                                "index": 19
-                            }
-                        }
-                    },
-                    "initializer": null,
-                    "comments": [
-                        {
-                            "loc": {
-                                "end": {
-                                    "column": 20,
-                                    "index": 31,
-                                    "line": 2
-                                },
-                                "start": {
-                                    "column": 10,
-                                    "index": 21,
-                                    "line": 2
-                                }
-                            },
-                            "type": "CommentBlock",
-                            "value": ["tail"]
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 5,
-                            "index": 16
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 8,
-                            "index": 19
-                        }
-                    }
-                }
-            ],
-            "comments": [],
+          "type": "EnumMember",
+          "name": {
+            "type": "Identifier",
+            "value": "ONE",
             "loc": {
+              "start": {
+                "line": 2,
+                "column": 5,
+                "index": 16
+              },
+              "end": {
+                "line": 2,
+                "column": 8,
+                "index": 19
+              }
+            }
+          },
+          "initializer": null,
+          "comments": [
+            {
+              "type": "CommentBlock",
+              "value": [
+                "tail"
+              ],
+              "loc": {
                 "start": {
-                    "line": 1,
-                    "column": 1,
-                    "index": 0
+                  "line": 2,
+                  "column": 10,
+                  "index": 21
                 },
                 "end": {
-                    "line": 4,
-                    "column": 2,
-                    "index": 43
+                  "line": 2,
+                  "column": 20,
+                  "index": 31
                 }
+              }
             }
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5,
+              "index": 16
+            },
+            "end": {
+              "line": 2,
+              "column": 8,
+              "index": 19
+            }
+          }
         }
-    ]
+      ],
+      "comments": [],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "index": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 2,
+          "index": 43
+        }
+      }
+    }
+  ]
 }

--- a/src/tests/parser/solutions/errors-complex.solution.json
+++ b/src/tests/parser/solutions/errors-complex.solution.json
@@ -1,21 +1,21 @@
 {
-    "type": "ThriftErrors",
-    "errors": [
-        {
-            "type": "ParseError",
-            "message": "FieldType expected but found: GreaterThanToken",
-            "loc": {
-                "start": {
-                    "line": 78,
-                    "column": 22,
-                    "index": 1928
-                },
-                "end": {
-                    "line": 78,
-                    "column": 23,
-                    "index": 1929
-                }
-            }
+  "type": "ThriftErrors",
+  "errors": [
+    {
+      "type": "ParseError",
+      "message": "FieldType expected but found: GreaterThanToken",
+      "loc": {
+        "start": {
+          "line": 80,
+          "column": 22,
+          "index": 1928
+        },
+        "end": {
+          "line": 80,
+          "column": 23,
+          "index": 1929
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/tests/parser/solutions/service-commented.solution.json
+++ b/src/tests/parser/solutions/service-commented.solution.json
@@ -1,108 +1,108 @@
 {
-    "type": "ThriftDocument",
-    "body": [
+  "type": "ThriftDocument",
+  "body": [
+    {
+      "type": "ServiceDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "Test",
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 9,
+            "index": 8
+          },
+          "end": {
+            "line": 1,
+            "column": 13,
+            "index": 12
+          }
+        }
+      },
+      "extends": null,
+      "functions": [
         {
-            "type": "ServiceDefinition",
-            "name": {
-                "type": "Identifier",
-                "value": "Test",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 9,
-                        "index": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 13,
-                        "index": 12
-                    }
-                }
-            },
-            "extends": null,
-            "functions": [
-                {
-                    "type": "FunctionDefinition",
-                    "name": {
-                        "type": "Identifier",
-                        "value": "test",
-                        "loc": {
-                            "start": {
-                                "line": 2,
-                                "column": 10,
-                                "index": 24
-                            },
-                            "end": {
-                                "line": 2,
-                                "column": 14,
-                                "index": 28
-                            }
-                        }
-                    },
-                    "returnType": {
-                        "type": "BoolKeyword",
-                        "loc": {
-                            "start": {
-                                "line": 2,
-                                "column": 5,
-                                "index": 19
-                            },
-                            "end": {
-                                "line": 2,
-                                "column": 9,
-                                "index": 23
-                            }
-                        }
-                    },
-                    "fields": [],
-                    "throws": [],
-                    "comments": [
-                        {
-                            "loc": {
-                                "end": {
-                                    "column": 24,
-                                    "index": 38,
-                                    "line": 2
-                                },
-                                "start": {
-                                    "column": 17,
-                                    "index": 31,
-                                    "line": 2
-                                }
-                            },
-                            "type": "CommentLine",
-                            "value": "tail"
-                        }
-                    ],
-                    "oneway": false,
-                    "modifiers": [],
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 5,
-                            "index": 19
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 16,
-                            "index": 30
-                        }
-                    }
-                }
-            ],
-            "comments": [],
+          "type": "FunctionDefinition",
+          "name": {
+            "type": "Identifier",
+            "value": "test",
             "loc": {
+              "start": {
+                "line": 2,
+                "column": 10,
+                "index": 24
+              },
+              "end": {
+                "line": 2,
+                "column": 14,
+                "index": 28
+              }
+            }
+          },
+          "returnType": {
+            "type": "BoolKeyword",
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 5,
+                "index": 19
+              },
+              "end": {
+                "line": 2,
+                "column": 9,
+                "index": 23
+              }
+            }
+          },
+          "fields": [],
+          "throws": [],
+          "comments": [
+            {
+              "type": "CommentLine",
+              "value": "tail",
+              "loc": {
                 "start": {
-                    "line": 1,
-                    "column": 1,
-                    "index": 0
+                  "line": 2,
+                  "column": 17,
+                  "index": 31
                 },
                 "end": {
-                    "line": 4,
-                    "column": 2,
-                    "index": 58
+                  "line": 2,
+                  "column": 24,
+                  "index": 38
                 }
+              }
             }
+          ],
+          "oneway": false,
+          "modifiers": [],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5,
+              "index": 19
+            },
+            "end": {
+              "line": 2,
+              "column": 16,
+              "index": 30
+            }
+          }
         }
-    ]
+      ],
+      "comments": [],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "index": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 2,
+          "index": 58
+        }
+      }
+    }
+  ]
 }

--- a/src/tests/parser/solutions/struct-commented.solution.json
+++ b/src/tests/parser/solutions/struct-commented.solution.json
@@ -1,121 +1,121 @@
 {
-    "type": "ThriftDocument",
-    "body": [
+  "type": "ThriftDocument",
+  "body": [
+    {
+      "type": "StructDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "Test",
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 8,
+            "index": 7
+          },
+          "end": {
+            "line": 1,
+            "column": 12,
+            "index": 11
+          }
+        }
+      },
+      "fields": [
         {
-            "type": "StructDefinition",
-            "name": {
-                "type": "Identifier",
-                "value": "Test",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8,
-                        "index": 7
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 12,
-                        "index": 11
-                    }
-                }
-            },
-            "fields": [
-                {
-                    "type": "FieldDefinition",
-                    "name": {
-                        "type": "Identifier",
-                        "value": "field1",
-                        "loc": {
-                            "start": {
-                                "line": 2,
-                                "column": 21,
-                                "index": 34
-                            },
-                            "end": {
-                                "line": 2,
-                                "column": 27,
-                                "index": 40
-                            }
-                        }
-                    },
-                    "fieldID": {
-                        "type": "FieldID",
-                        "value": 1,
-                        "loc": {
-                            "start": {
-                                "line": 2,
-                                "column": 5,
-                                "index": 18
-                            },
-                            "end": {
-                                "line": 2,
-                                "column": 7,
-                                "index": 20
-                            }
-                        }
-                    },
-                    "fieldType": {
-                        "type": "I32Keyword",
-                        "loc": {
-                            "start": {
-                                "line": 2,
-                                "column": 17,
-                                "index": 30
-                            },
-                            "end": {
-                                "line": 2,
-                                "column": 20,
-                                "index": 33
-                            }
-                        }
-                    },
-                    "requiredness": "required",
-                    "defaultValue": null,
-                    "comments": [
-                        {
-                            "loc": {
-                                "end": {
-                                    "column": 36,
-                                    "index": 49,
-                                    "line": 2
-                                },
-                                "start": {
-                                    "column": 29,
-                                    "index": 42,
-                                    "line": 2
-                                }
-                            },
-                            "type": "CommentLine",
-                            "value": "tail"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 5,
-                            "index": 18
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 28,
-                            "index": 41
-                        }
-                    }
-                }
-            ],
-            "comments": [],
+          "type": "FieldDefinition",
+          "name": {
+            "type": "Identifier",
+            "value": "field1",
             "loc": {
+              "start": {
+                "line": 2,
+                "column": 21,
+                "index": 34
+              },
+              "end": {
+                "line": 2,
+                "column": 27,
+                "index": 40
+              }
+            }
+          },
+          "fieldID": {
+            "type": "FieldID",
+            "value": 1,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 5,
+                "index": 18
+              },
+              "end": {
+                "line": 2,
+                "column": 7,
+                "index": 20
+              }
+            }
+          },
+          "fieldType": {
+            "type": "I32Keyword",
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 17,
+                "index": 30
+              },
+              "end": {
+                "line": 2,
+                "column": 20,
+                "index": 33
+              }
+            }
+          },
+          "requiredness": "required",
+          "defaultValue": null,
+          "comments": [
+            {
+              "type": "CommentLine",
+              "value": "tail",
+              "loc": {
                 "start": {
-                    "line": 1,
-                    "column": 1,
-                    "index": 0
+                  "line": 2,
+                  "column": 29,
+                  "index": 42
                 },
                 "end": {
-                    "line": 4,
-                    "column": 2,
-                    "index": 82
+                  "line": 2,
+                  "column": 36,
+                  "index": 49
                 }
+              }
             }
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5,
+              "index": 18
+            },
+            "end": {
+              "line": 2,
+              "column": 28,
+              "index": 41
+            }
+          }
         }
-    ]
+      ],
+      "comments": [],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "index": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 2,
+          "index": 82
+        }
+      }
+    }
+  ]
 }

--- a/src/tests/parser/solutions/typedef-commented.solution.json
+++ b/src/tests/parser/solutions/typedef-commented.solution.json
@@ -1,71 +1,71 @@
 {
-    "type": "ThriftDocument",
-    "body": [
-        {
-            "type": "TypedefDefinition",
-            "name": {
-                "type": "Identifier",
-                "value": "name",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 37,
-                        "index": 36
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 41,
-                        "index": 40
-                    }
-                }
-            },
-            "definitionType": {
-                "type": "StringKeyword",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 30,
-                        "index": 29
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 36,
-                        "index": 35
-                    }
-                }
-            },
-            "comments": [
-                {
-                    "type": "CommentBlock",
-                    "value": [
-                        "string is name"
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 9,
-                            "index": 8
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 29,
-                            "index": 28
-                        }
-                    }
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 1,
-                    "index": 0
-                },
-                "end": {
-                    "line": 1,
-                    "column": 41,
-                    "index": 40
-                }
-            }
+  "type": "ThriftDocument",
+  "body": [
+    {
+      "type": "TypedefDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "name",
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 9,
+            "index": 36
+          },
+          "end": {
+            "line": 2,
+            "column": 13,
+            "index": 40
+          }
         }
-    ]
+      },
+      "definitionType": {
+        "type": "StringKeyword",
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 2,
+            "index": 29
+          },
+          "end": {
+            "line": 2,
+            "column": 8,
+            "index": 35
+          }
+        }
+      },
+      "comments": [
+        {
+          "type": "CommentBlock",
+          "value": [
+            "string is name"
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9,
+              "index": 8
+            },
+            "end": {
+              "line": 1,
+              "column": 29,
+              "index": 28
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "index": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 13,
+          "index": 40
+        }
+      }
+    }
+  ]
 }

--- a/src/tests/scanner/solutions/comment-block.solution.json
+++ b/src/tests/scanner/solutions/comment-block.solution.json
@@ -1,114 +1,114 @@
 [
-    {
-        "type": "CommentBlock",
-        "text": "This is a struct\n it does things",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 1,
-                "index": 0
-            },
-            "end": {
-                "line": 3,
-                "column": 4,
-                "index": 41
-            }
-        }
-    },
-    {
-        "type": "CommentBlock",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 4,
-                "column": 1,
-                "index": 42
-            },
-            "end": {
-                "line": 5,
-                "column": 3,
-                "index": 48
-            }
-        }
-    },
-    {
-        "type": "CommentBlock",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 6,
-                "column": 1,
-                "index": 49
-            },
-            "end": {
-                "line": 7,
-                "column": 3,
-                "index": 54
-            }
-        }
-    },
-    {
-        "type": "CommentBlock",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 8,
-                "column": 1,
-                "index": 55
-            },
-            "end": {
-                "line": 8,
-                "column": 5,
-                "index": 59
-            }
-        }
-    },
-    {
-        "type": "CommentBlock",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 9,
-                "column": 1,
-                "index": 60
-            },
-            "end": {
-                "line": 9,
-                "column": 6,
-                "index": 65
-            }
-        }
-    },
-    {
-        "type": "CommentBlock",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 10,
-                "column": 1,
-                "index": 66
-            },
-            "end": {
-                "line": 10,
-                "column": 7,
-                "index": 72
-            }
-        }
-    },
-    {
-        "type": "EOF",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 10,
-                "column": 7,
-                "index": 73
-            },
-            "end": {
-                "line": 11,
-                "column": 1,
-                "index": 73
-            }
-        }
+  {
+    "type": "CommentBlock",
+    "text": "This is a struct\n it does things",
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 1,
+        "index": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 4,
+        "index": 41
+      }
     }
+  },
+  {
+    "type": "CommentBlock",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 1,
+        "index": 42
+      },
+      "end": {
+        "line": 6,
+        "column": 3,
+        "index": 48
+      }
+    }
+  },
+  {
+    "type": "CommentBlock",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 1,
+        "index": 49
+      },
+      "end": {
+        "line": 8,
+        "column": 3,
+        "index": 54
+      }
+    }
+  },
+  {
+    "type": "CommentBlock",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 1,
+        "index": 55
+      },
+      "end": {
+        "line": 9,
+        "column": 5,
+        "index": 59
+      }
+    }
+  },
+  {
+    "type": "CommentBlock",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 1,
+        "index": 60
+      },
+      "end": {
+        "line": 10,
+        "column": 6,
+        "index": 65
+      }
+    }
+  },
+  {
+    "type": "CommentBlock",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 1,
+        "index": 66
+      },
+      "end": {
+        "line": 11,
+        "column": 7,
+        "index": 72
+      }
+    }
+  },
+  {
+    "type": "EOF",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 7,
+        "index": 73
+      },
+      "end": {
+        "line": 12,
+        "column": 1,
+        "index": 73
+      }
+    }
+  }
 ]

--- a/src/tests/scanner/solutions/comment-empty.solution.json
+++ b/src/tests/scanner/solutions/comment-empty.solution.json
@@ -1,114 +1,114 @@
 [
-    {
-        "type": "CommentLine",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 1,
-                "index": 0
-            },
-            "end": {
-                "line": 1,
-                "column": 3,
-                "index": 2
-            }
-        }
-    },
-    {
-        "type": "ConstKeyword",
-        "text": "const",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 3,
-                "index": 2
-            },
-            "end": {
-                "line": 1,
-                "column": 8,
-                "index": 7
-            }
-        }
-    },
-    {
-        "type": "I32Keyword",
-        "text": "i32",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 9,
-                "index": 8
-            },
-            "end": {
-                "line": 1,
-                "column": 12,
-                "index": 11
-            }
-        }
-    },
-    {
-        "type": "Identifier",
-        "text": "id",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 13,
-                "index": 12
-            },
-            "end": {
-                "line": 1,
-                "column": 15,
-                "index": 14
-            }
-        }
-    },
-    {
-        "type": "EqualToken",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 16,
-                "index": 15
-            },
-            "end": {
-                "line": 1,
-                "column": 17,
-                "index": 16
-            }
-        }
-    },
-    {
-        "type": "IntegerLiteral",
-        "text": "45",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 18,
-                "index": 17
-            },
-            "end": {
-                "line": 1,
-                "column": 20,
-                "index": 19
-            }
-        }
-    },
-    {
-        "type": "EOF",
-        "text": "",
-        "loc": {
-            "start": {
-                "line": 1,
-                "column": 20,
-                "index": 20
-            },
-            "end": {
-                "line": 2,
-                "column": 1,
-                "index": 20
-            }
-        }
+  {
+    "type": "CommentLine",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 1,
+        "index": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 3,
+        "index": 2
+      }
     }
+  },
+  {
+    "type": "ConstKeyword",
+    "text": "const",
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 1,
+        "index": 2
+      },
+      "end": {
+        "line": 2,
+        "column": 6,
+        "index": 7
+      }
+    }
+  },
+  {
+    "type": "I32Keyword",
+    "text": "i32",
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 7,
+        "index": 8
+      },
+      "end": {
+        "line": 2,
+        "column": 10,
+        "index": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "text": "id",
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 11,
+        "index": 12
+      },
+      "end": {
+        "line": 2,
+        "column": 13,
+        "index": 14
+      }
+    }
+  },
+  {
+    "type": "EqualToken",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 14,
+        "index": 15
+      },
+      "end": {
+        "line": 2,
+        "column": 15,
+        "index": 16
+      }
+    }
+  },
+  {
+    "type": "IntegerLiteral",
+    "text": "45",
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 16,
+        "index": 17
+      },
+      "end": {
+        "line": 2,
+        "column": 18,
+        "index": 19
+      }
+    }
+  },
+  {
+    "type": "EOF",
+    "text": "",
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 18,
+        "index": 20
+      },
+      "end": {
+        "line": 3,
+        "column": 1,
+        "index": 20
+      }
+    }
+  }
 ]


### PR DESCRIPTION
example 
```
/*
* test 
*/
```

If a comment in this format appears, the content line information below the comment will be biased.

```
//
// test
```
Another case is that if the comment is followed by empty content, there will also be a problem with the line number below.